### PR TITLE
Add None check for regex match in day10.1

### DIFF
--- a/2025/day10.1.py
+++ b/2025/day10.1.py
@@ -5,6 +5,8 @@ from year2025.day10 import IndicatorLights, Buttons, process
 def parse_line(line):
     # Parse indicator lights: [...]
     lights_match = re.search(r'\[([^\]]+)\]', line)
+    if not lights_match:
+        raise ValueError(f"No indicator lights found in line: {line}")
     indicator_lights = IndicatorLights(lights_match.group(1))
 
     # Parse all button groups: (...)


### PR DESCRIPTION
## Summary
- Add guard for `re.search` returning `None` in `parse_line` to fix Pylance `reportOptionalMemberAccess` warning
- Raises a clear `ValueError` if indicator lights pattern is not found in input line